### PR TITLE
chore: fix CMakeLists.txt and include paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,19 +4,47 @@ project(main)
 
 set(CMAKE_C_STANDARD 99)
 
-add_library(os STATIC src/OS/os.c)
-add_library(util STATIC src/util.c)
-add_library(network STATIC src/L2/network.c)
-add_library(dummy STATIC src/L2/interfaces/dummy.c)
-add_library(loopback STATIC src/L2/interfaces/loopback.c)
+
+add_library(os SHARED src/OS/os.c)
+target_include_directories(os PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:include/mylib>  # <prefix>/include/mylib
+)
+add_library(util SHARED src/util.c)
+target_include_directories(util PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:include/mylib>  # <prefix>/include/mylib
+)
+add_library(network SHARED src/L2/network.c)
+target_include_directories(network PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:include/mylib>  # <prefix>/include/mylib
+)
+add_library(dummy SHARED src/L2/interfaces/dummy.c)
+target_include_directories(dummy PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:include/mylib>  # <prefix>/include/mylib
+)
+add_library(loopback SHARED src/L2/interfaces/loopback.c)
+target_include_directories(loopback PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:include/mylib>  # <prefix>/include/mylib
+)
 if(UNIX)
-  add_library(linux STATIC src/OS/linux.c)
+  add_library(linux SHARED src/OS/linux.c)
+  target_include_directories(linux PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:include/mylib>  # <prefix>/include/mylib
+)
 else()
-  add_library(windows STATIC src/OS/windows.c)
+  add_library(windows SHARED src/OS/windows.c)
+  target_include_directories(windows PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:include/mylib>  # <prefix>/include/mylib
+)
 endif()
 
-set(library os util dummy network)
-set(library os util loopback network)
+set(library os util dummy loopback network)
 
 add_executable(os_osinit_test.exe ./test/os_osinit_test.c)
 add_executable(util_log_test.exe ./test/util_log_test.c)

--- a/src/L2/interfaces/dummy.h
+++ b/src/L2/interfaces/dummy.h
@@ -25,7 +25,7 @@
 #include <stdint.h>
 #include <stdio.h>
 
-#include "../network.h"
+#include "src/L2/network.h"
 
 extern IFNET *DummyInit(void);
 

--- a/src/L2/interfaces/loopback.c
+++ b/src/L2/interfaces/loopback.c
@@ -20,9 +20,9 @@
 #include <stdint.h>
 #include <stdio.h>
 
-#include "../../type.h"
-#include "../../util.h"
-#include "../network.h"
+#include "src/type.h"
+#include "src/util.h"
+#include "src/L2/network.h"
 
 static int LoopbackOutput(IFNET *interface, const uint8_t *data,
                           const void *dst) {

--- a/src/L2/interfaces/loopback.h
+++ b/src/L2/interfaces/loopback.h
@@ -23,7 +23,7 @@
 #ifndef LOOPBACK_H
 #define LOOPBACK_H
 
-#include "../network.h"
+#include "src/L2/network.h"
 
 extern IFNET *LoopbackInit(void);
 

--- a/src/L2/network.c
+++ b/src/L2/network.c
@@ -20,9 +20,9 @@
 #include <stdint.h>
 #include <stdio.h>
 
-#include "../OS/os.h"
-#include "../type.h"
-#include "../util.h"
+#include "src/OS/os.h"
+#include "src/type.h"
+#include "src/util.h"
 
 IFNET *interfaces;
 IFADDR *addrlists;

--- a/src/L2/network.h
+++ b/src/L2/network.h
@@ -25,7 +25,7 @@
 #include <stdint.h>
 #include <stdio.h>
 
-#include "../OS/os.h"
+#include "src/OS/os.h"
 
 typedef struct if_data {
     uint8_t ifi_type;

--- a/src/OS/os.c
+++ b/src/OS/os.c
@@ -19,7 +19,7 @@
 
 #include <stdio.h>
 
-#include "../type.h"
+#include "src/type.h"
 #include "linux.h"
 #include "unix.h"
 #include "windows.h"

--- a/src/util.c
+++ b/src/util.c
@@ -20,7 +20,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-#include "OS/os.h"
+#include "src/OS/os.h"
 
 /*
  * Log


### PR DESCRIPTION
fix CMakeLists.txt like:

add_library(linux SHARED src/OS/linux.c)
  target_include_directories(linux PUBLIC
  .$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
  $<INSTALL_INTERFACE:include/mylib>  # <prefix>/include/mylib
)

and change include paths like:
"../../foo.h" -> "src/bar/foo.h"